### PR TITLE
Removed Serilog and disabled logging

### DIFF
--- a/NArctic/NArctic.csproj
+++ b/NArctic/NArctic.csproj
@@ -14,7 +14,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -61,12 +61,6 @@
     </Reference>
     <Reference Include="MongoDB.Driver.Core, Version=2.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Driver.Core.2.5.0\lib\net45\MongoDB.Driver.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/NArctic/packages.config
+++ b/NArctic/packages.config
@@ -5,7 +5,6 @@
   <package id="MongoDB.Bson" version="2.5.0" targetFramework="net45" />
   <package id="MongoDB.Driver" version="2.5.0" targetFramework="net45" />
   <package id="MongoDB.Driver.Core" version="2.5.0" targetFramework="net45" />
-  <package id="Serilog" version="1.5.14" targetFramework="net45" />
   <package id="System.Buffers" version="4.3.0" targetFramework="net45" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Allows for the removal of Serilog binding
Logging statements have been disabled via conditional compilation (LOG)
Logging will be re-enabled once the path to adding abstract logging in Net45 becomes clearer